### PR TITLE
Allow environment to be installed with Python 3.12+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "pyspedas",
     "spacepy",
     "sunpy[all]",
-    "numpy<2.0.0"  # most core packages don't yet support Numpy 2
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
If I remember correctly, `pyhc-core` only works on Python ≤ 3.11 since Kamodo currently doesn't work on Python ≥ 3.12.  This PR makes installation of Kamodo contingent upon the version of Python being Python < 3.12. 

## Tasks

I'm making this a draft PR sort of as a placeholder, but hopefully I'll have a chance to come back to these tasks.

 - [x] Update `pyproject.toml`
 - [ ] Test installation with Python 3.12 & 3.13
 - [ ] Double check that Kamodo still doesn't work on Python 3.12+
 - [ ] Add task to #9 to revert this PR when Kamodo supports Python 3.12+